### PR TITLE
Add snapcraft.yaml to build a snap of gtop

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,17 @@
+name: gtop
+version: git
+summary: System monitoring dashboard for terminal
+description: |
+  System monitoring dashboard for terminal
+
+grade: stable
+confinement: devmodeg
+
+apps:
+  gtop:
+    command: gtop
+
+parts:
+  gtop:
+    plugin: nodejs
+    source: https://github.com/aksakalli/gtop.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,7 +5,7 @@ description: |
   System monitoring dashboard for terminal
 
 grade: stable
-confinement: devmodeg
+confinement: devmode
 
 apps:
   gtop:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,4 +14,4 @@ apps:
 parts:
   gtop:
     plugin: nodejs
-    source: https://github.com/aksakalli/gtop.git
+    source: .


### PR DESCRIPTION
Thanks for making gtop! It's very pretty, and I'm a sucker for terminal based system monitors. :)

This pull request adds support for creating a snap of gtop. Snaps are universal software packages for Linux. If you choose to land this PR then you (as the project owner) can use http://build.snapcraft.io/ to automatically build a snap on each commit to master, and publish to the snap store, for free. 

Once the snap is in the edge channel in the store, users on snap-supported Linux distros can simply ```snap install gtop --edge --devmode```. 

To find out more about snapcraft and snaps, see http://snapcraft.io/ and http://snapcraft.io/docs . 