### PR TITLE
Fixes "NaN%" being displayed with untouched swap

### DIFF
--- a/lib/monitor/mem.js
+++ b/lib/monitor/mem.js
@@ -41,6 +41,8 @@ Mem.prototype.updateData = function(data) {
   var memPer = (100 * (1 - data.available / data.total)).toFixed(1);
   var swapPer = (100 * (1 - data.swapfree / data.swaptotal)).toFixed(1);
 
+  swapPer = isNaN(swapPer) ? 0 : swapPer;
+
   this.memData[0].y.shift();
   this.memData[0].y.push(memPer);
 


### PR DESCRIPTION
Currently `swapPer` returns `NaN` when the system's swap is uninitialised:

![screen shot 2017-08-11 at 11 45 10](https://user-images.githubusercontent.com/8663099/29212744-73f2d052-7ea0-11e7-9814-1a9597e7b6aa.png)

This pull request fixes this issue by checking for `isNaN()` and setting `swapPer = 0` if true.