### PR TITLE
Update installation instructions to include 'sudo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ System monitoring dashboard for terminal.
 ### Installation
 
 ```
-$ npm install gtop -g
+$ sudo npm install gtop -g
 ```
 
 ### Usage


### PR DESCRIPTION
Tried on my Ubuntu 17 machine, sudo was required to execute the installation command.