### PR TITLE
Add command line flags for which windows to show

### DIFF
--- a/bin/gtop
+++ b/bin/gtop
@@ -1,3 +1,19 @@
 #!/usr/bin/env node
 
-require('../lib/gtop').init()
+if (process.argv[2] === '--help') {
+  console.log(`
+    gtop [-cpu|-mem|-net|-disk|-proc]
+
+    With no flags supplied gtop runs all on default
+    Adding flags will show only the windows for the flags supplied
+
+    -cpu: Show the cpu usage window
+    -mem: Show the memory usage window
+    -net: Show the network history window
+    -disk: Show the disk usage window
+    -proc: Show the running processes window
+  `);
+} else {
+  let flags = process.argv.slice(2);
+  require('../lib/gtop').init(flags)
+}

--- a/lib/gtop.js
+++ b/lib/gtop.js
@@ -83,7 +83,11 @@ screen.key(['escape', 'q', 'C-c'], function(ch, key) {
   return process.exit(0);
 });
 
-function init() {
+function init(flags) {
+  flags.length === 0 ? showAll() : showSelected(flags);
+}
+
+function showAll() {
   new monitor.Cpu(cpuLine); //no Windows support
   new monitor.Mem(memLine, memDonut, swapDonut);
   new monitor.Net(netSpark);
@@ -91,6 +95,29 @@ function init() {
   new monitor.Proc(procTable); // no Windows support
 }
 
+function showSelected(flags) {
+  flags.forEach((flag) => {
+    switch(flag) {
+      case '-cpu':
+        new monitor.Cpu(cpuLine);
+        break;
+      case '-mem':
+        new monitor.Mem(memLine, memDonut, swapDonut);
+        break;
+      case '-net':
+        new monitor.Net(netSpark);
+        break;
+      case '-disk':
+        new monitor.Disk(diskDonut);
+        break;
+      case '-proc':
+        new monitor.Proc(procTable);
+        break;
+      default:
+        break;
+    }
+  });
+}
 
 process.on('uncaughtException', function(err) {
   // avoid exiting due to unsupported system resources in Windows


### PR DESCRIPTION
Add --help flag and also flags for which windows to show.

```
gtop [-cpu|-mem|-net|-disk|-proc]
+
+    With no flags supplied gtop runs all on default
+    Adding flags will show only the windows for the flags supplied
+
+    -cpu: Show the cpu usage window
+    -mem: Show the memory usage window
+    -net: Show the network history window
+    -disk: Show the disk usage window
+    -proc: Show the running processes window
```

But this just turns the windows on or off basically, it doesn't resize the windows sizes it shows a blank box if the window is off. There will be a lot of changes to code and order of functions to correctly resize each window depending on which are selected. 

Any feedback?