### PR TITLE
show nvidia gpu utilization when available - closes 39

### DIFF
--- a/lib/gtop.js
+++ b/lib/gtop.js
@@ -1,96 +1,121 @@
 var blessed = require('blessed'),
   contrib = require('blessed-contrib'),
-  monitor = require('./monitor');
-
-
-var screen = blessed.screen()
-var grid = new contrib.grid({
-  rows: 12,
-  cols: 12,
-  screen: screen
-})
-
-var cpuLine = grid.set(0, 0, 4, 12, contrib.line, {
-  showNthLabel: 5,
-  maxY: 100,
-  label: 'CPU History',
-  showLegend: true,
-})
-
-var memLine = grid.set(4, 0, 4, 8, contrib.line, {
-  showNthLabel: 5,
-  maxY: 100,
-  label: 'Memory and Swap History',
-  showLegend: true,
-  legend: {
-    width: 10
-  }
-})
-
-var memDonut = grid.set(4, 8, 2, 4, contrib.donut, {
-  radius: 8,
-  arcWidth: 3,
-  yPadding: 2,
-  remainColor: 'black',
-  label: 'Memory',
-});
-
-var swapDonut = grid.set(6, 8, 2, 4, contrib.donut, {
-  radius: 8,
-  arcWidth: 3,
-  yPadding: 2,
-  remainColor: 'black',
-  label: 'Swap',
-});
-
-var netSpark = grid.set(8, 0, 2, 6, contrib.sparkline, {
-  label: 'Network History',
-  tags: true,
-  style: {
-    fg: 'blue'
-  }
-})
-
-var diskDonut = grid.set(10, 0, 2, 6, contrib.donut, {
-  radius: 8,
-  arcWidth: 3,
-  yPadding: 2,
-  remainColor: 'black',
-  label: 'Disk usage',
-})
-
-var procTable = grid.set(8, 6, 4, 6, contrib.table, {
-  keys: true,
-  label: 'Processes',
-  columnSpacing: 1,
-  columnWidth: [7, 24, 7, 7]
-})
-
-procTable.focus()
-
-screen.render();
-screen.on('resize', function(a) {
-  cpuLine.emit('attach');
-  memLine.emit('attach');
-  memDonut.emit('attach');
-  swapDonut.emit('attach');
-  netSpark.emit('attach');
-  diskDonut.emit('attach');
-  procTable.emit('attach');
-});
-
-screen.key(['escape', 'q', 'C-c'], function(ch, key) {
-  return process.exit(0);
-});
+  monitor = require('./monitor'),
+  exec = require('child_process').exec;
 
 function init() {
+  let supportsNvidiaSmi = false;
+
+  exec('nvidia-smi -L | wc -l', (error, stdout) => {
+    if (!error && parseInt(stdout, 10) > 0) {
+      supportsNvidiaSmi = true;
+    }
+    render({ supportsNvidiaSmi });
+  });
+}
+
+function render({ supportsNvidiaSmi }) {
+  var screen = blessed.screen()
+  var grid = new contrib.grid({
+    rows: supportsNvidiaSmi ? 16 : 12,
+    cols: 12,
+    screen: screen
+  })
+
+  var cpuLine = grid.set(0, 0, 4, 12, contrib.line, {
+    showNthLabel: 5,
+    maxY: 100,
+    label: 'CPU History',
+    showLegend: true,
+  })
+
+  var memLine = grid.set(4, 0, 4, 8, contrib.line, {
+    showNthLabel: 5,
+    maxY: 100,
+    label: 'Memory and Swap History',
+    showLegend: true,
+    legend: {
+      width: 10
+    }
+  })
+
+  var memDonut = grid.set(4, 8, 2, 4, contrib.donut, {
+    radius: 8,
+    arcWidth: 3,
+    yPadding: 2,
+    remainColor: 'black',
+    label: 'Memory',
+  });
+
+  var swapDonut = grid.set(6, 8, 2, 4, contrib.donut, {
+    radius: 8,
+    arcWidth: 3,
+    yPadding: 2,
+    remainColor: 'black',
+    label: 'Swap',
+  });
+
+  var netSpark = grid.set(8, 0, 2, 6, contrib.sparkline, {
+    label: 'Network History',
+    tags: true,
+    style: {
+      fg: 'blue'
+    }
+  })
+
+  var diskDonut = grid.set(10, 0, 2, 6, contrib.donut, {
+    radius: 8,
+    arcWidth: 3,
+    yPadding: 2,
+    remainColor: 'black',
+    label: 'Disk usage',
+  })
+
+  var procTable = grid.set(8, 6, 4, 6, contrib.table, {
+    keys: true,
+    label: 'Processes',
+    columnSpacing: 1,
+    columnWidth: [7, 24, 7, 7]
+  })
+
+  if (supportsNvidiaSmi) {
+    var gpuLine = grid.set(12, 0, 4, 12, contrib.line, {
+      showNthLabel: 5,
+      maxY: 100,
+      label: 'GPU History',
+      showLegend: true,
+    })
+  }
+
+  procTable.focus()
+
+  screen.render();
+  screen.on('resize', function(a) {
+    cpuLine.emit('attach');
+    memLine.emit('attach');
+    memDonut.emit('attach');
+    swapDonut.emit('attach');
+    netSpark.emit('attach');
+    diskDonut.emit('attach');
+    procTable.emit('attach');
+    if (supportsNvidiaSmi) {
+      gpuLine.emit('attach');
+    }
+  });
+
+  screen.key(['escape', 'q', 'C-c'], function(ch, key) {
+    return process.exit(0);
+  });
+
   new monitor.Cpu(cpuLine); //no Windows support
   new monitor.Mem(memLine, memDonut, swapDonut);
   new monitor.Net(netSpark);
   new monitor.Disk(diskDonut);
   new monitor.Proc(procTable); // no Windows support
+  if (supportsNvidiaSmi) {
+    new monitor.Gpu(gpuLine);
+  }
 }
-
 
 process.on('uncaughtException', function(err) {
   // avoid exiting due to unsupported system resources in Windows

--- a/lib/monitor/gpu.js
+++ b/lib/monitor/gpu.js
@@ -1,0 +1,64 @@
+const { exec } = require('child_process');
+const { colors } = require('../utils');
+
+function gpuInfoCmd (gpuId) {
+  return `nvidia-smi --id=${gpuId} --query-gpu=utilization.gpu,utilization.memory --format=csv`;
+}
+
+function getNvidiaData (gpuId) {
+  return new Promise(resolve => {
+    const cmd = gpuInfoCmd(gpuId);
+    exec(cmd, (error, stdout) => {
+      if (error) {
+        return reject(error);
+      }
+      const utilization = parseUtilization(stdout);
+      resolve(utilization);
+    });
+  });
+}
+
+function parseUtilization (data) {
+  const lines = data.split('\n');
+  const values = lines[1].split(',');
+
+  return {
+    load: parseInt(values[0], 10),
+    memory: parseInt(values[1], 10)
+  };
+}
+
+class Gpu {
+  constructor(line) {
+    this.line = line;
+    this.gpus = [{}];
+    this.gpuData = this.gpus.map((_, i) => ({
+      title: `GPU ${i+1}`,
+      style: {
+        line: colors[i % colors.length],
+      },
+      x: Array(61).fill().map((_, i) => 60 - i),
+      y: Array(61).fill(0),
+    }));
+    this.render();
+    this.interval = setInterval(() => this.render(), 1000);
+  }
+
+  render() {
+    this.gpus.forEach((gpu, i) => {
+      getNvidiaData(i)
+        .then((data) => this.updateGpuData(data, i))
+        .catch(err => console.error(err));
+    });
+    this.line.setData(this.gpuData);
+    this.line.screen.render();
+  }
+
+  updateGpuData(data, i) {
+    this.gpuData[i].title = `GPU${i+1} ${data.load}%`;
+    this.gpuData[i].y.shift();
+    this.gpuData[i].y.push(data.load);
+  }
+}
+
+module.exports = Gpu;

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   Cpu: require('./cpu'),
+  Gpu: require('./gpu'),
   Mem: require('./mem'),
   Net: require('./net'),
   Disk: require('./disk'),


### PR DESCRIPTION
This adds `nvidia-smi` GPU utilization, as requested in [issue 39](https://github.com/aksakalli/gtop/issues/39)

If any `nvidia-smi` compatible cards are found, the grid size is increased and a 'GPU History' section is added at the bottom. Otherwise, the UI remains the same.

This was my first stab at working in this repo, feedback is greatly appreciated!

![screenshot](https://user-images.githubusercontent.com/1626240/33309003-7ff6db56-d3d1-11e7-830c-c7121fc651e7.png)