### PR TITLE
Kill process from within the process table

### DIFF
--- a/lib/monitor/proc.js
+++ b/lib/monitor/proc.js
@@ -1,4 +1,5 @@
-var si = require('systeminformation'),
+var si  = require('systeminformation'),
+  kill  = require('fkill'),
   utils = require('../utils');
 
 var colors = utils.colors;
@@ -36,6 +37,14 @@ function Proc(table) {
 
     that.reIndex = true;
     updater();
+  });
+
+  this.table.rows.on('select', function(item, idx) {
+    var pid = item.parent.value.substr(0, item.parent.value.indexOf(' '));
+    kill(parseInt(pid)).then(() => {
+      that.reIndex = true;
+      updater();
+    });
   });
 
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.7.5",
-    "systeminformation": "^3.25.1"
+    "systeminformation": "^3.25.1",
+    "fkill": "^5.3.0"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
This is a small feature that basically allows one to navigate the process table with the arrows (as it can already be done) but kill a process by pressing "enter" (or selecting a row). 