### PR TITLE
Adding realtime Hostname value to the dashboard

### DIFF
--- a/lib/gtop.js
+++ b/lib/gtop.js
@@ -17,6 +17,12 @@ var cpuLine = grid.set(0, 0, 4, 12, contrib.line, {
   showLegend: true,
 })
 
+var hostnameWidget = grid.set(0, 8, 1, 2, contrib.markdown, {
+  label: "HOSTNAME",
+  fg: "green",
+  selectedFg: "green"
+})
+
 var memLine = grid.set(4, 0, 4, 8, contrib.line, {
   showNthLabel: 5,
   maxY: 100,
@@ -89,6 +95,7 @@ function init() {
   new monitor.Net(netSpark);
   new monitor.Disk(diskDonut);
   new monitor.Proc(procTable); // no Windows support
+  new monitor.Host(hostnameWidget);
 }
 
 

--- a/lib/monitor/hostname.js
+++ b/lib/monitor/hostname.js
@@ -1,0 +1,21 @@
+var si = require('systeminformation'),
+    utils = require('../utils');
+
+var colors = utils.colors;
+
+function Host(markdown) {
+    this.markdown = markdown;
+
+    this.interval = setInterval(() => {
+        this.updateData();
+      }, 1000);
+}
+
+Host.prototype.updateData = function () {
+    si.osInfo((info) => {
+        this.markdown.setMarkdown(info.hostname);
+    })
+}
+
+
+module.exports = Host;

--- a/lib/monitor/index.js
+++ b/lib/monitor/index.js
@@ -3,5 +3,6 @@ module.exports = {
   Mem: require('./mem'),
   Net: require('./net'),
   Disk: require('./disk'),
-  Proc: require('./proc')
+  Proc: require('./proc'),
+  Host: require('./hostname')
 }


### PR DESCRIPTION
Added a Markdown widget to the dashboard, displaying the Hostname value, updated every 1 second.

Reference issue: https://github.com/aksakalli/gtop/issues/87