### PR TITLE
Executable to run gtop in docker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ docker run --rm -it \
 
 Run gtop in your terminal, but in a docker container by running the following lines.
 ```sh
-$ curl -fSsL https://raw.githubusercontent.com/aksakalli/gtop/master/gtop-docker.sh; sudo chmod +x gtop-docker.sh; sudo mv gtop-docker.sh /usr/local/bin/gtop
+$ sh -c "$(curl -fSsL https://raw.githubusercontent.com/snpranav/gtop/master/gtop-docker.sh)"
 
 $ gtop		# Run gtop from your terminal whenever you want to open gtop.
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ docker run --rm -it \
 
 -OR-
 
-Run gtop in your terminal, but in a docker container by running the following lines.
+Run gtop in your terminal using the `gtop` command, but in a docker container by running the following lines.
 ```sh
 $ sh -c "$(curl -fSsL https://raw.githubusercontent.com/snpranav/gtop/master/gtop-docker.sh)"
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ $ docker run --rm -it \
     aksakalli/gtop
 ```
 
+-OR-
+
+Run gtop in your terminal, but in a docker container by running the following lines.
+```sh
+$ curl -fSsL https://raw.githubusercontent.com/aksakalli/gtop/master/gtop-docker.sh; sudo chmod +x gtop-docker.sh; sudo mv gtop-docker.sh /usr/local/bin/gtop
+
+$ gtop		# Run gtop from your terminal whenever you want to open gtop.
+```
+
 ### Usage
 
 Start gtop with the `gtop` command

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ docker run --rm -it \
 
 Run gtop in your terminal using the `gtop` command, but in a docker container by running the following lines.
 ```sh
-$ sh -c "$(curl -fSsL https://raw.githubusercontent.com/snpranav/gtop/master/gtop-docker.sh)"
+$ sh -c "$(curl -fSsL https://raw.githubusercontent.com/aksakalli/gtop/master/gtop-docker.sh)"
 
 $ gtop		# Run gtop from your terminal whenever you want to open gtop.
 ```

--- a/gtop-docker.sh
+++ b/gtop-docker.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
+sudo tee /usr/local/bin/gtop > /dev/null << EOF
 docker run --rm -it \
 	--name gtop-from-executable \
 	--net="host" \
 	--pid="host" \
 	aksakalli/gtop
+EOF
+
+sudo chmod 100 /usr/local/bin/gtop

--- a/gtop-docker.sh
+++ b/gtop-docker.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+#########################################
+# Run gtop in your terminal using the `gtop` command, but in a docker container by running the following lines.
+# ```sh
+# $ sh -c "$(curl -fSsL https://raw.githubusercontent.com/aksakalli/gtop/master/gtop-docker.sh)"
+
+# $ gtop		# Run gtop from your terminal whenever you want to open gtop.
+#########################################
+
 sudo tee /usr/local/bin/gtop > /dev/null << EOF
 docker run --rm -it \
 	--name gtop-from-executable \

--- a/gtop-docker.sh
+++ b/gtop-docker.sh
@@ -8,4 +8,4 @@ docker run --rm -it \
 	aksakalli/gtop
 EOF
 
-sudo chmod a+x /usr/local/bin/gtop
+sudo chmod 555 /usr/local/bin/gtop

--- a/gtop-docker.sh
+++ b/gtop-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker run --rm -it \
+	--name gtop-from-executable \
+	--net="host" \
+	--pid="host" \
+	aksakalli/gtop

--- a/gtop-docker.sh
+++ b/gtop-docker.sh
@@ -8,4 +8,4 @@ docker run --rm -it \
 	aksakalli/gtop
 EOF
 
-sudo chmod 100 /usr/local/bin/gtop
+sudo chmod a+x /usr/local/bin/gtop


### PR DESCRIPTION
I wrote a shell script called `gtop-docker.sh` that creates an executable in the `/usr/local/bin` folder, so that users can run the `gtop` command in the terminal as a CLI tool, without the need of nodejs as the executable creates and destroys gtop docker containers.

This will be very helpful for users that do not have nodejs installed on their host machine or for those that do not want to install any external node packages.