### PR TITLE
upgrade node version for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v2.1.5
+      - name: Use Node.js 17.x
+        uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: '17.x'
       - name: Install dependencies
         run: npm ci
       - name: Lint check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '17.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm publish


### PR DESCRIPTION
v1.1.3 release action failed due to old node version not able to install pair dependency: [publishing run](https://github.com/aksakalli/gtop/runs/4795357461?check_suite_focus=true) gives

```
> gtop@1.1.3 prepublishOnly .
> marked-man --version $npm_package_version --manual 'Gtop Help' --section 1 ./CLI.md > gtop.1

internal/modules/cjs/loader.js:818
  throw err;
  ^

Error: Cannot find module 'marked'
Require stack:
- /home/runner/work/gtop/gtop/node_modules/marked-man/lib/marked-man.js
- /home/runner/work/gtop/gtop/node_modules/marked-man/bin/marked-man
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/runner/work/gtop/gtop/node_modules/marked-man/lib/marked-man.js:1:14)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/runner/work/gtop/gtop/node_modules/marked-man/lib/marked-man.js',
    '/home/runner/work/gtop/gtop/node_modules/marked-man/bin/marked-man'
  ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! gtop@1.1.3 prepublishOnly: `marked-man --version $npm_package_version --manual 'Gtop Help' --section 1 ./CLI.md > gtop.1`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the gtop@1.1.3 prepublishOnly script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-01-12T21_07_25_319Z-debug.log
Error: Process completed with exit code 1.
```

upgrading NodeJS version will solve it since I don't have the same problem while publishing in my local machine with a more recent NodeJS version.