### PR TITLE
snap/snapcraft: pin to v1.1.5 release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: gtop
 summary: System monitoring dashboard for terminal
 description: |
   System monitoring dashboard for terminal
-version: git
+version: v1.1.5
 base: core22
 grade: stable
 
@@ -14,7 +14,8 @@ apps:
 
 parts:
   gtop:
-    source: .
+    source: https://github.com/aksakalli/gtop.git
+    source-tag: ${SNAPCRAFT_PROJECT_VERSION}
     plugin: npm
     npm-include-node: true
     npm-node-version: "17.3.0"


### PR DESCRIPTION
Instead of using `source: .`  we can pull the source from github. This has the following benefits:

* allow us to set the `source-tag`. This pulls the gtop source into a temp directory and checks out the tag. This means we don't have to worry about dirty builds.
* The snap name will automatically have `${SNAPCRAFT_PROJECT_VERSION}` in it instead of the git hash when using `version: git`.

To update the snap build, all you will need to do is update `version: v1.1.5` to the tag that you want to build.