### PR TITLE
Fix disk usage reporting by improving partition selection logic

### DIFF
--- a/lib/monitor/disk.js
+++ b/lib/monitor/disk.js
@@ -18,7 +18,24 @@ function Disk(donut) {
 }
 
 Disk.prototype.updateData = function(data) {
-  var disk = data[0];
+  var disk;
+
+  // Filter out very small filesystems (< 100MB) to avoid system partitions
+  var relevantFilesystems = data.filter(fs => fs.size > 100 * 1024 * 1024);
+
+  if (process.platform === 'darwin') {
+    // macOS: prefer /System/Volumes/Data or root, or largest
+    disk = relevantFilesystems.find(fs => fs.mount === '/System/Volumes/Data') ||
+           relevantFilesystems.find(fs => fs.mount === '/') ||
+           relevantFilesystems.reduce((prev, curr) => prev.size > curr.size ? prev : curr, relevantFilesystems[0]);
+  } else {
+    // Linux/Unix: find root filesystem or largest
+    disk = relevantFilesystems.find(fs => fs.mount === '/') ||
+           relevantFilesystems.reduce((prev, curr) => prev.size > curr.size ? prev : curr, relevantFilesystems[0]);
+  }
+
+  // Fallback to first filesystem if nothing found
+  disk = disk || data[0];
 
   var label =
     utils.humanFileSize(disk.used, true) +


### PR DESCRIPTION
## Summary

This PR fixes the disk usage reporting issues where gtop would often display incorrect partition information by improving the partition selection logic in `disk.js`.

## Problem

The original implementation simply used `data[0]` (the first filesystem returned by systeminformation), which often pointed to system partitions, swap files, or other irrelevant filesystems instead of the main user data partition. This caused significant discrepancies between gtop's reported disk usage and what users would see in system tools like `df` or macOS Storage Management.

## Solution

The improved implementation:

1. **Filters out small filesystems** (< 100MB) to avoid system partitions, swap files, and other non-user-data filesystems
2. **Platform-specific logic**:
   - **macOS**: Prioritizes `/System/Volumes/Data` (Catalina+), then `/` (root), then falls back to the largest filesystem
   - **Linux/Unix**: Prioritizes `/` (root filesystem), then falls back to the largest filesystem
3. **Intelligent fallback**: If no suitable filesystem is found, falls back to the original behavior

## Issues Fixed

This addresses several reported issues:

- **Issue #118**: "Disk usage is different than what reported by df on the Ubuntu" - The fix ensures gtop prioritizes the root filesystem (`/`) on Linux systems, matching `df` behavior
- **Issue #99**: "Disk usage is different than what is reported by Storage Management on macOS Catalina" - The fix specifically handles macOS Catalina's `/System/Volumes/Data` mount point
- **Issue #127**: Related disk reporting inconsistencies

## Changes Made

- Enhanced `updateData()` function in `lib/monitor/disk.js`
- Added filesystem filtering logic to exclude system partitions
- Implemented platform-specific partition selection
- Maintained backward compatibility with fallback logic

## Testing

The changes have been tested to ensure:
- Proper root filesystem detection on Linux systems
- Correct handling of macOS filesystem structure (including Catalina+)
- Fallback behavior works when expected filesystems aren't found
- No breaking changes to existing functionality

This improvement makes gtop's disk usage reporting much more accurate and consistent with standard system tools.